### PR TITLE
Fix hydration error in ThemeToggle by deferring render until mounted

### DIFF
--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -5,13 +5,20 @@ import { Checkbox, Label } from '@/components/ui';
 import { CiDark, CiLight } from 'react-icons/ci';
 import { cn } from '@/lib/utils';
 import { buttonVariants } from './ui/button';
+import { useEffect, useState } from 'react';
 
 export default function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState<boolean>(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleChangeTheme = () => {
     setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
   };
+
+  if (!mounted) return null;
 
   return (
     <div>


### PR DESCRIPTION
This PR fixes a hydration mismatch issue in the `ThemeToggle` component. The problem happened because the theme context (`resolvedTheme`) was accessed before the component fully mounted, leading to differences between server and client renders.

To resolve it, I added a mounted state that ensures the component only renders after the initial mount. This makes sure `resolvedTheme` has the correct value and avoids hydration issues during SSR.

Closes #21